### PR TITLE
Fixed empty MS2 handling in createLibrary

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@
 - Empty identification will not longer raise error but the pipeline will finish outputting no IDs
 - Fixed duplicated codes to make the pipeline code more compact
 - Added centroiding option for MS2 ions
+- Fixed empty MS2 handling in createLibrary
 
 ## [v1.0.1](https://github.com/nf-core/metaboigniter/releases/tag/1.0.1) - 2021-05-11
 

--- a/bin/createLibrary.r
+++ b/bin/createLibrary.r
@@ -172,6 +172,22 @@ source("/usr/bin/createLibraryFun.r")
 library(stringr)
 
 
+MappedMS2s$mapped<-lapply(MappedMS2s$mapped,function(x){
+
+  lst_filtered<-lapply(x,function(y){if(y@peaksCount>minPeaks){y}})
+  lst_filtered[lengths(lst_filtered) != 0]
+
+})
+
+index_of_not_null<-which(!sapply(MappedMS2s$mapped,function(x){all(sapply(x,function(y){(is.null(y))}))}))
+if(length(index_of_not_null)==0)
+{
+  stop("All MS2s are empty!")
+}
+
+MappedMS2s$mapped<-MappedMS2s$mapped[index_of_not_null]
+
+
 createLibrary(MSMSdata = MappedMS2s,libraryInfo,requiredHeader,whichmz=whichmz,
                    cameraObject = cameraObject,includeUnmapped = F,savePath=output,
                    includeMapped = T,preprocess = F, minPeaks=minPeaks,


### PR DESCRIPTION
This PR fixes errors due to empty MS2 spectra. 

<!--
# nf-core/metaboigniter pull request

Many thanks for contributing to nf-core/metaboigniter!

Please fill in the appropriate checklist below (delete whatever is not relevant).
These are the most common things requested on pull requests (PRs).

Remember that PRs should be made against the dev branch, unless you're preparing a pipeline release.

Learn more about contributing: [CONTRIBUTING.md](https://github.com/nf-core/metaboigniter/tree/master/.github/CONTRIBUTING.md)
-->
<!-- markdownlint-disable ul-indent -->

## PR checklist

- [ ] This comment contains a description of changes (with reason).
- [ ] If you've fixed a bug or added code that should be tested, add tests!
    - [ ] If you've added a new tool - add to the software_versions process and a regex to `scrape_software_versions.py`
    - [ ] If you've added a new tool - have you followed the pipeline conventions in the [contribution docs](<https://github.com/>nf-core/metaboigniter/tree/master/.github/CONTRIBUTING.md)
    - [ ] If necessary, also make a PR on the nf-core/metaboigniter _branch_ on the [nf-core/test-datasets](https://github.com/nf-core/test-datasets) repository.
- [ ] Make sure your code lints (`nf-core lint .`).
- [ ] Ensure the test suite passes (`nextflow run . -profile test,docker`).
- [ ] Usage Documentation in `docs/usage.md` is updated.
- [ ] Output Documentation in `docs/output.md` is updated.
- [ ] `CHANGELOG.md` is updated.
- [ ] `README.md` is updated (including new tool citations and authors/contributors).
